### PR TITLE
release(modulisto): v2.4.0

### DIFF
--- a/packages/modulisto/CHANGELOG.md
+++ b/packages/modulisto/CHANGELOG.md
@@ -1,3 +1,31 @@
+# Changelog
+
+---
+## [2.4.0](https://github.com/arxdeus/modulisto/compare/modulisto-v2.3.0..2.4.0) - 2025-03-16
+
+### Bug Fixes
+
+- `PipelineRef` now implements `ModuleChild` - ([abfa596](https://github.com/arxdeus/modulisto/commit/abfa5961f90d421a957dc2083cd752551aed61eb))
+- add missing export for `settings.dart` - ([b4be30f](https://github.com/arxdeus/modulisto/commit/b4be30f3ce08ccdab403ef939e43f3e5ce921bad))
+
+### Features
+
+- **(operation)** expando nullify at dispose + tests - ([78e039a](https://github.com/arxdeus/modulisto/commit/78e039a028d6579f522207e0b862883406b7b344))
+- `Operation<T>` - special indirect unit that wraps around functions - ([70b43ed](https://github.com/arxdeus/modulisto/commit/70b43ed44b6ba972a0b9b7cca056cae6acc64a8e))
+- pipeline linker for `Operation<T>` - ([a964f68](https://github.com/arxdeus/modulisto/commit/a964f6859636535713a0008ea4ef8d49e7b91c64))
+- settings for package + `debugReportTypeMismatchOnOperation` - ([b049543](https://github.com/arxdeus/modulisto/commit/b04954371cc4ad2d2482022ea29687a720ac0fde))
+- integrate `OperationRunner` in `Module` - ([daba526](https://github.com/arxdeus/modulisto/commit/daba5269c170e08a9537fca812caf4ddfdbdb6b9))
+- hide `debugName` + assign `debugName` to `Module` on `initialize` - ([779dca9](https://github.com/arxdeus/modulisto/commit/779dca9777342a8df65500310d47c132fb14ad23))
+- operation tests - ([921d995](https://github.com/arxdeus/modulisto/commit/921d995c968fbebbfaa9cb3afe243f348dc07f18))
+
+### Miscellaneous Chores
+
+- mark `module` with `$` as internal marker - ([c4898e5](https://github.com/arxdeus/modulisto/commit/c4898e5680597e16a0c337f1f4423cc94d873964))
+
+### Ci
+
+- major update + fix lints - ([7329f15](https://github.com/arxdeus/modulisto/commit/7329f153d6608ba43e7639277d72aed62e36bbe4))
+
 ## 2.2.1
 
 * fix: remove unneccessary flutter sdk constraint in `pubspec.yaml`

--- a/packages/modulisto/pubspec.yaml
+++ b/packages/modulisto/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modulisto
 description: An advanced state management solution with any number of event flows
-version: 2.2.1
+version: 2.4.0
 resolution: workspace
 homepage: https://github.com/kitsuniru/modulisto
 repository: https://github.com/kitsuniru/modulisto

--- a/packages/modulisto_flutter/pubspec.yaml
+++ b/packages/modulisto_flutter/pubspec.yaml
@@ -26,7 +26,7 @@ environment:
   flutter: ">=3.27.0"
 
 dependencies:
-  modulisto: ^2.2.1
+  modulisto: ^2.4.0
   meta: ^1.15.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
# Changelog

---
## [2.4.0](https://github.com/arxdeus/modulisto/compare/modulisto-v2.3.0..2.4.0) - 2025-03-16

### Bug Fixes

- `PipelineRef` now implements `ModuleChild` - ([abfa596](https://github.com/arxdeus/modulisto/commit/abfa5961f90d421a957dc2083cd752551aed61eb))
- add missing export for `settings.dart` - ([b4be30f](https://github.com/arxdeus/modulisto/commit/b4be30f3ce08ccdab403ef939e43f3e5ce921bad))

### Features

- **(operation)** expando nullify at dispose + tests - ([78e039a](https://github.com/arxdeus/modulisto/commit/78e039a028d6579f522207e0b862883406b7b344))
- `Operation<T>` - special indirect unit that wraps around functions - ([70b43ed](https://github.com/arxdeus/modulisto/commit/70b43ed44b6ba972a0b9b7cca056cae6acc64a8e))
- pipeline linker for `Operation<T>` - ([a964f68](https://github.com/arxdeus/modulisto/commit/a964f6859636535713a0008ea4ef8d49e7b91c64))
- settings for package + `debugReportTypeMismatchOnOperation` - ([b049543](https://github.com/arxdeus/modulisto/commit/b04954371cc4ad2d2482022ea29687a720ac0fde))
- integrate `OperationRunner` in `Module` - ([daba526](https://github.com/arxdeus/modulisto/commit/daba5269c170e08a9537fca812caf4ddfdbdb6b9))
- hide `debugName` + assign `debugName` to `Module` on `initialize` - ([779dca9](https://github.com/arxdeus/modulisto/commit/779dca9777342a8df65500310d47c132fb14ad23))
- operation tests - ([921d995](https://github.com/arxdeus/modulisto/commit/921d995c968fbebbfaa9cb3afe243f348dc07f18))

### Miscellaneous Chores

- mark `module` with `$` as internal marker - ([c4898e5](https://github.com/arxdeus/modulisto/commit/c4898e5680597e16a0c337f1f4423cc94d873964))

### Ci

- major update + fix lints - ([7329f15](https://github.com/arxdeus/modulisto/commit/7329f153d6608ba43e7639277d72aed62e36bbe4))

